### PR TITLE
Add option for queue namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,15 @@ You must define both the AMQP URL and a logger instance:
 
 ```ruby
 SongkickQueue.configure do |config|
-  config.amqp = 'amqp://localhost:5672'
-  config.logger = Logger.new(STDOUT)
+  config.amqp = 'amqp://localhost:5672'    # required
+  config.logger = Logger.new(STDOUT)       # required
+  config.queue_namespace = ENV['RACK_ENV'] # optional
 end
 ```
+
+You can also optionally define a namespace to apply to your queue names automatically when
+publishing and consuming. This can be useful to isolate environments that share the same RabbitMQ
+instance.
 
 ### Creating consumers
 

--- a/lib/songkick_queue.rb
+++ b/lib/songkick_queue.rb
@@ -9,7 +9,7 @@ require 'songkick_queue/worker'
 require 'songkick_queue/cli'
 
 module SongkickQueue
-  Configuration = Struct.new(:amqp, :logger)
+  Configuration = Struct.new(:amqp, :logger, :queue_namespace)
   ConfigurationError = Class.new(StandardError)
 
   # Retrieve configuration for SongkickQueue

--- a/lib/songkick_queue/consumer.rb
+++ b/lib/songkick_queue/consumer.rb
@@ -14,8 +14,14 @@ module SongkickQueue
       #
       # @raise [NotImplementedError] if queue name was not already defined
       def queue_name
-        @queue_name || fail(NotImplementedError, 'you must declare a queue name to consume from ' +
+        @queue_name or fail(NotImplementedError, 'you must declare a queue name to consume from ' +
           'by calling #consume_from_queue in your consumer class. See README for more info.')
+
+        [config.queue_namespace, @queue_name].compact.join('.')
+      end
+
+      def config
+        SongkickQueue.configuration
       end
     end
 

--- a/lib/songkick_queue/producer.rb
+++ b/lib/songkick_queue/producer.rb
@@ -17,9 +17,18 @@ module SongkickQueue
       client
         .default_exchange
         .publish(payload, routing_key: routing_key)
+
+      logger.info "Published message to #{routing_key}"
     end
 
     private
+
+    # Retrieve the logger defined in the configuration
+    #
+    # @raise [ConfigurationError] if not defined
+    def logger
+      config.logger || fail(ConfigurationError, 'No logger configured, see README for more details')
+    end
 
     def config
       SongkickQueue.configuration

--- a/lib/songkick_queue/producer.rb
+++ b/lib/songkick_queue/producer.rb
@@ -12,12 +12,18 @@ module SongkickQueue
     def publish(queue_name, message)
       payload = JSON.generate(message)
 
+      routing_key = [config.queue_namespace, queue_name].compact.join('.')
+
       client
         .default_exchange
-        .publish(payload, routing_key: String(queue_name))
+        .publish(payload, routing_key: routing_key)
     end
 
     private
+
+    def config
+      SongkickQueue.configuration
+    end
 
     attr_reader :client
   end

--- a/lib/songkick_queue/version.rb
+++ b/lib/songkick_queue/version.rb
@@ -1,3 +1,3 @@
 module SongkickQueue
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/lib/songkick_queue/worker.rb
+++ b/lib/songkick_queue/worker.rb
@@ -65,7 +65,7 @@ module SongkickQueue
     # @param consumer_class [Class] to subscribe to
     def subscribe_to_queue(consumer_class)
       queue = channel.queue(consumer_class.queue_name, durable: true,
-        arguments: {'x-ha-policy' => 'all'})
+        arguments: { 'x-ha-policy' => 'all' })
 
       queue.subscribe(manual_ack: true) do |delivery_info, properties, payload|
         process_message(consumer_class, delivery_info, properties, payload)

--- a/spec/songkick_queue/consumer_spec.rb
+++ b/spec/songkick_queue/consumer_spec.rb
@@ -20,6 +20,18 @@ module SongkickQueue
 
         expect(ExampleConsumer.queue_name).to eq 'app.examples'
       end
+
+      it "should add the configured namespace to the queue name" do
+        class ExampleConsumer
+          include SongkickQueue::Consumer
+
+          consume_from_queue 'app.examples'
+        end
+
+        allow(ExampleConsumer).to receive(:config) { double(queue_namespace: 'test-env') }
+
+        expect(ExampleConsumer.queue_name).to eq 'test-env.app.examples'
+      end
     end
 
     describe "#initialize" do

--- a/spec/songkick_queue/producer_spec.rb
+++ b/spec/songkick_queue/producer_spec.rb
@@ -10,8 +10,13 @@ module SongkickQueue
         client = instance_double(Client, default_exchange: exchange)
         allow(producer).to receive(:client) { client }
 
+        logger = double(:logger, info: true)
+        allow(producer).to receive(:logger) { logger }
+
         expect(exchange).to receive(:publish)
           .with('{"example":"message","value":true}', routing_key: 'queue_name')
+
+        expect(logger).to receive(:info).with('Published message to queue_name')
 
         producer.publish(:queue_name, { example: 'message', value: true })
       end
@@ -23,8 +28,13 @@ module SongkickQueue
         client = instance_double(Client, default_exchange: exchange)
         allow(producer).to receive(:client) { client }
 
+        logger = double(:logger, info: true)
+        allow(producer).to receive(:logger) { logger }
+
         expect(exchange).to receive(:publish)
           .with('{"example":"message","value":true}', routing_key: 'test-env.queue_name')
+
+        expect(logger).to receive(:info).with('Published message to test-env.queue_name')
 
         allow(producer).to receive(:config) { double(queue_namespace: 'test-env') }
 

--- a/spec/songkick_queue/producer_spec.rb
+++ b/spec/songkick_queue/producer_spec.rb
@@ -15,6 +15,21 @@ module SongkickQueue
 
         producer.publish(:queue_name, { example: 'message', value: true })
       end
+
+      it "should publish with a routing key using the configured queue namespace" do
+        producer = Producer.new
+
+        exchange = double(:exchange, publish: :published)
+        client = instance_double(Client, default_exchange: exchange)
+        allow(producer).to receive(:client) { client }
+
+        expect(exchange).to receive(:publish)
+          .with('{"example":"message","value":true}', routing_key: 'test-env.queue_name')
+
+        allow(producer).to receive(:config) { double(queue_namespace: 'test-env') }
+
+        producer.publish(:queue_name, { example: 'message', value: true })
+      end
     end
   end
 end


### PR DESCRIPTION
Allows a namespace to be configured for use when producing and consuming messages.

From the updated README:

```ruby
SongkickQueue.configure do |config|
  config.amqp = 'amqp://localhost:5672'    # required
  config.logger = Logger.new(STDOUT)       # required
  config.queue_namespace = ENV['RACK_ENV'] # optional
end
```

> You can also optionally define a namespace to apply to your queue names automatically when publishing and consuming. This can be useful to isolate environments that share the same RabbitMQ instance.