### PR TITLE
Add ID and timestamp to produced messages

### DIFF
--- a/lib/songkick_queue.rb
+++ b/lib/songkick_queue.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'securerandom'
 require 'bunny'
 
 require 'songkick_queue/version'

--- a/lib/songkick_queue.rb
+++ b/lib/songkick_queue.rb
@@ -29,10 +29,9 @@ module SongkickQueue
 
   # Publishes the given message to the given queue
   #
-  # @param queue_name [String] to publish to
-  # @param message [#to_json] to serialize and enqueue
-  def self.publish(queue_name, message)
-    producer.publish(queue_name, message)
+  # @see SongkickQueue::Producer#publish for argument documentation
+  def self.publish(queue_name, message, options = {})
+    producer.publish(queue_name, message, options = {})
   end
 
   private

--- a/lib/songkick_queue/producer.rb
+++ b/lib/songkick_queue/producer.rb
@@ -9,6 +9,8 @@ module SongkickQueue
     #
     # @param queue_name [String] to publish to
     # @param message [#to_json] to serialize and enqueue
+    # @option options [String] :message_id to pass through to the consumer (will be logged)
+    # @option options [String] :produced_at time when the message was created, ISO8601 formatted
     def publish(queue_name, payload, options = {})
       message_id = options.fetch(:message_id) { SecureRandom.hex(6) }
       produced_at = options.fetch(:produced_at) { Time.now.utc.iso8601 }

--- a/lib/songkick_queue/producer.rb
+++ b/lib/songkick_queue/producer.rb
@@ -9,16 +9,25 @@ module SongkickQueue
     #
     # @param queue_name [String] to publish to
     # @param message [#to_json] to serialize and enqueue
-    def publish(queue_name, message)
-      payload = JSON.generate(message)
+    def publish(queue_name, payload, options = {})
+      message_id = options.fetch(:message_id) { SecureRandom.hex(6) }
+      produced_at = options.fetch(:produced_at) { Time.new.utc.iso8601 }
+
+      message = {
+        message_id: message_id,
+        produced_at: produced_at,
+        payload: payload
+      }
+
+      message = JSON.generate(message)
 
       routing_key = [config.queue_namespace, queue_name].compact.join('.')
 
       client
         .default_exchange
-        .publish(payload, routing_key: routing_key)
+        .publish(message, routing_key: routing_key)
 
-      logger.info "Published message to #{routing_key}"
+      logger.info "Published message #{message_id} to '#{routing_key}' at #{produced_at}"
     end
 
     private

--- a/lib/songkick_queue/producer.rb
+++ b/lib/songkick_queue/producer.rb
@@ -11,7 +11,7 @@ module SongkickQueue
     # @param message [#to_json] to serialize and enqueue
     def publish(queue_name, payload, options = {})
       message_id = options.fetch(:message_id) { SecureRandom.hex(6) }
-      produced_at = options.fetch(:produced_at) { Time.new.utc.iso8601 }
+      produced_at = options.fetch(:produced_at) { Time.now.utc.iso8601 }
 
       message = {
         message_id: message_id,

--- a/lib/songkick_queue/worker.rb
+++ b/lib/songkick_queue/worker.rb
@@ -67,8 +67,8 @@ module SongkickQueue
       queue = channel.queue(consumer_class.queue_name, durable: true,
         arguments: { 'x-ha-policy' => 'all' })
 
-      queue.subscribe(manual_ack: true) do |delivery_info, properties, payload|
-        process_message(consumer_class, delivery_info, properties, payload)
+      queue.subscribe(manual_ack: true) do |delivery_info, properties, message|
+        process_message(consumer_class, delivery_info, properties, message)
       end
 
       logger.info "Subscribed #{consumer_class} to #{consumer_class.queue_name}"
@@ -79,16 +79,19 @@ module SongkickQueue
     # @param consumer_class [Class] that was subscribed to
     # @param delivery_info [Bunny::DeliveryInfo]
     # @param properties [Bunny::MessageProperties]
-    # @param payload [String] to deserialize
-    def process_message(consumer_class, delivery_info, properties, payload)
-      logger.info "Processing message via #{consumer_class}..."
+    # @param message [String] to deserialize
+    def process_message(consumer_class, delivery_info, properties, message)
+      message = JSON.parse(message, symbolize_names: true)
 
+      # Handle both old and new format of messages
+      # TODO: Tidy this up once messages always have a payload
+      payload = message.fetch(:payload, message)
+
+      logger.info "Processing message via #{consumer_class}..."
       set_process_name(consumer_class)
 
-      message = JSON.parse(payload, symbolize_names: true)
-
       consumer = consumer_class.new(delivery_info, logger)
-      consumer.process(message)
+      consumer.process(payload)
     rescue Object => exception
       logger.error(exception)
     ensure

--- a/lib/songkick_queue/worker.rb
+++ b/lib/songkick_queue/worker.rb
@@ -118,14 +118,13 @@ module SongkickQueue
     #
     # @example idle
     #   set_process_name #=> "songkick_queue[idle]"
-    # @example consumer running
-    #   set_process_name(TweetConsumer) #=> "songkick_queue[tweet_consumer]"
+    # @example consumer running, namespace is removed
+    #   set_process_name(Foo::TweetConsumer) #=> "songkick_queue[TweetConsumer]"
     # @param status [String] of the program
     def set_process_name(status = 'idle')
       formatted_status = String(status)
-        .gsub('::', '')
-        .gsub(/([A-Z]+)/) { "_#{$1.downcase}" }
-        .sub(/^_(\w)/) { $1 }
+        .split('::')
+        .last
 
       $PROGRAM_NAME = "#{process_name}[#{formatted_status}]"
     end

--- a/spec/songkick_queue/producer_spec.rb
+++ b/spec/songkick_queue/producer_spec.rb
@@ -14,11 +14,14 @@ module SongkickQueue
         allow(producer).to receive(:logger) { logger }
 
         expect(exchange).to receive(:publish)
-          .with('{"example":"message","value":true}', routing_key: 'queue_name')
+          .with('{"message_id":"92c583bdc248","produced_at":"2015-03-30T15:41:55Z",' +
+            '"payload":{"example":"message","value":true}}', routing_key: 'queue_name')
 
-        expect(logger).to receive(:info).with('Published message to queue_name')
+        expect(logger).to receive(:info)
+          .with("Published message 92c583bdc248 to 'queue_name' at 2015-03-30T15:41:55Z")
 
-        producer.publish(:queue_name, { example: 'message', value: true })
+        producer.publish(:queue_name, { example: 'message', value: true },
+          message_id: '92c583bdc248', produced_at: '2015-03-30T15:41:55Z')
       end
 
       it "should publish with a routing key using the configured queue namespace" do
@@ -32,13 +35,16 @@ module SongkickQueue
         allow(producer).to receive(:logger) { logger }
 
         expect(exchange).to receive(:publish)
-          .with('{"example":"message","value":true}', routing_key: 'test-env.queue_name')
+          .with('{"message_id":"92c583bdc248","produced_at":"2015-03-30T15:41:55Z",' +
+            '"payload":{"example":"message","value":true}}', routing_key: 'test-env.queue_name')
 
-        expect(logger).to receive(:info).with('Published message to test-env.queue_name')
+        expect(logger).to receive(:info)
+          .with("Published message 92c583bdc248 to 'test-env.queue_name' at 2015-03-30T15:41:55Z")
 
         allow(producer).to receive(:config) { double(queue_namespace: 'test-env') }
 
-        producer.publish(:queue_name, { example: 'message', value: true })
+        producer.publish(:queue_name, { example: 'message', value: true },
+          message_id: '92c583bdc248', produced_at: '2015-03-30T15:41:55Z')
       end
     end
   end

--- a/spec/songkick_queue_spec.rb
+++ b/spec/songkick_queue_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SongkickQueue do
       producer = instance_double(SongkickQueue::Producer)
       allow(SongkickQueue).to receive(:producer) { producer }
 
-      expect(producer).to receive(:publish).with(:queue_name, :message)
+      expect(producer).to receive(:publish).with(:queue_name, :message, {})
 
       SongkickQueue.publish(:queue_name, :message)
     end


### PR DESCRIPTION
- [x] Add message ID to produced messages
- [x] Add "produced at" timestamp
- [x] Allow consumers to handle both old and new message formats